### PR TITLE
Add Freetar addon

### DIFF
--- a/freetar/CHANGELOG.md
+++ b/freetar/CHANGELOG.md
@@ -1,0 +1,5 @@
+<!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
+
+## 0.14.0
+
+- Initial release

--- a/freetar/Dockerfile
+++ b/freetar/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-alpine
+
+ENV PYTHONUNBUFFERED=TRUE \
+    PORT=22201 \
+    HOST=0.0.0.0
+
+RUN adduser -D freetar && \
+    pip install --no-cache-dir freetar==0.14.0
+
+USER freetar
+EXPOSE 22201
+
+CMD ["sh", "-c", "waitress-serve --listen=${HOST}:${PORT} freetar.backend:app"]

--- a/freetar/README.md
+++ b/freetar/README.md
@@ -1,0 +1,24 @@
+# Freetar for Home Assistant
+
+This add-on packages [Freetar](https://github.com/kmille/freetar), an open source alternative front-end to Ultimate Guitar.
+
+## 🔗 Usage
+
+After installing, access the Web UI at:
+`http://<YOUR_HOME_ASSISTANT_IP>:22201/`
+
+## 🛠️ Configuration
+
+No additional configuration is required for basic usage.
+
+![Supports aarch64 Architecture][aarch64-shield]
+![Supports amd64 Architecture][amd64-shield]
+![Supports armhf Architecture][armhf-shield]
+![Supports armv7 Architecture][armv7-shield]
+![Supports i386 Architecture][i386-shield]
+
+[aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
+[amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
+[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
+[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
+[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/freetar/build.yaml
+++ b/freetar/build.yaml
@@ -1,0 +1,6 @@
+build_from:
+  aarch64: "ghcr.io/hassio-addons/base/aarch64:16.0.0"
+  armv7: "ghcr.io/hassio-addons/base/armv7:16.0.0"
+  armhf: "ghcr.io/hassio-addons/base/armhf:16.0.0"
+  amd64: "ghcr.io/hassio-addons/base/amd64:16.0.0"
+  i386: "ghcr.io/hassio-addons/base/i386:16.0.0"

--- a/freetar/config.yaml
+++ b/freetar/config.yaml
@@ -1,0 +1,26 @@
+name: Freetar
+version: "0.14.0"
+slug: freetar
+description: Alternative front-end to Ultimate Guitar
+url: "https://github.com/kmille/freetar"
+image: "christopherjnash/freetar"
+
+arch:
+  - armhf
+  - armv7
+  - aarch64
+  - amd64
+  - i386
+
+init: false
+
+ports:
+  22201/tcp: 22201
+ports_description:
+  22201/tcp: Freetar Web Interface
+
+environment:
+  PORT: "22201"
+  HOST: "0.0.0.0"
+
+webui: "http://[HOST]:[PORT:22201]"


### PR DESCRIPTION
## Summary
- add Home Assistant addon for Freetar

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6861ae0260c8832099c72639f3db6ca2